### PR TITLE
M1macへの環境適応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     tty: true
     stdin_open: true
   db:
+    platform: linux/x86_64
     image: mysql:5.7
     volumes:
       - db-volume:/var/lib/mysql


### PR DESCRIPTION
docker-compose.ymlがM1macに対応していなかったため、急遽対応