### PR TITLE
アプリ内共通のフォントサイズ／色を設定

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,3 +14,15 @@
  *= require_tree .
  */
 
+
+/* アプリ内の文字色 */
+body {
+  color: #25507C;
+}
+/* アプリ内の文字サイズ */
+h1 {
+  font-size: 24px;
+}
+p {
+  font-size: 16px;
+}


### PR DESCRIPTION
# やったこと
- application.cssにアプリ内共通のフォントサイズと色を追加

# コメント
- flash文については考慮していないです。※後日相談希望
- 色をカラーコードで記述している理由は、フォント色の変数化はgeneral.scssで行っておりapplication.cssよりあとに読み込まれるためです。